### PR TITLE
Wandb integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ out/
 imagenet-mini/
 artifacts/
 pml.sif
+wandb/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Generally, you should be able to open the .tex document that you are interested 
 ## How to Log with Weights and Biases
 
 1. You need to have a [Weights and Biases](https://wandb.ai/site/) (wandb) account
-2. Add your wandb api key to your environment variables `export WANDB_API_KEY=<your key>`
+2. Add your wandb api key to your environment variables `export WANDB_API_KEY=<your key>`. If you run train the model within an apptainer make sure to add the environment variable to your `pml.def`-file
 3. Create an experiment by adjusting the `config.yaml`-file. make sure `log_wandb=True`
 
 ## How to run

--- a/README.md
+++ b/README.md
@@ -34,7 +34,22 @@ Generally, you should be able to open the .tex document that you are interested 
     - Shortcut: Ctrl + Click in the PDF Preview
     - Description: Jumps from a location in the PDF preview back to the corresponding place in the .tex source
 
-## How to run on cluster?
+## How to run
+
+### Using the CLI
+
+To run start the training, you can run the training script with
+`python src/pml_vqvae/train.py`
+
+On default (without extra parameters givin in the command), the training script will look up the `config.yaml`-file and will train according those defined parameters.
+
+If you want to change the default values you can either change them in the `config.yaml` or you can pass the values yu want to change via the cli, e.g.
+
+    python src/pml_vqvae/train.py --learning_rate 0.1
+
+This will take the `config.yaml` as the foundation and overwrites all the given values passed in the command. See the `python src/pml_vqvae/train.py -h` for more information.
+
+### Running on Cluster
 
 1. ssh to cluster entry-node by `ssh <username>@hydra.ml.tu-berlin.de`
 2. Build container if not exist, see Section [Build Container](#build-container)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Generally, you should be able to open the .tex document that you are interested 
     - Shortcut: Ctrl + Click in the PDF Preview
     - Description: Jumps from a location in the PDF preview back to the corresponding place in the .tex source
 
+## How to Log with Weights and Biases
+
+1. You need to have a [Weights and Biases](https://wandb.ai/site/) (wandb) account
+2. Add your wandb api key to your environment variables `export WANDB_API_KEY=<your key>`
+3. Create an experiment by adjusting the `config.yaml`-file. make sure `log_wandb=True`
+
 ## How to run
 
 ### Using the CLI

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,18 @@
+experiment:
+  name: "BaselineAutoencoder" # name of the experiment
+  description: "First attempt to train BaselineAutoencoder" # description of the experiment
+  seed: 42 # seed for reproducibility
+
+data:
+  n_train: 10 # number of training samples
+  n_test: 10 # number of test samples
+  dataset: "cifar" # either cifar or imagenet
+
+train:
+  batch_size: 32
+  epochs: 10
+  learning_rate: 0.01
+
+model:
+  model_name: "autoencoder" # either autoencoder or vae
+  

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,9 @@
 experiment:
-  name: "BaselineAutoencoder" # name of the experiment
-  description: "First attempt to train BaselineAutoencoder" # description of the experiment
+  name: "BaselineVae" # name of the experiment
+  description: "Test Vae Logging" # description of the experiment
   seed: 42 # seed for reproducibility
-  test_interval: 5  # test the model every test_interval epochs, None to disable
-  vis_train_interval: 5 # plot the training loss every plot_train_interval epochs, None to disable
+  test_interval: 1  # test the model every test_interval epochs, None to disable
+  vis_train_interval: 1 # plot the training loss every plot_train_interval epochs, None to disable
   wandb_log: True # log the experiment to wandb
 
 data:

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,8 @@ experiment:
   name: "BaselineAutoencoder" # name of the experiment
   description: "First attempt to train BaselineAutoencoder" # description of the experiment
   seed: 42 # seed for reproducibility
+  test_interval: 5  # test the model every test_interval epochs, None to disable
+  vis_train_interval: 5 # plot the training loss every plot_train_interval epochs, None to disable
 
 data:
   n_train: 10 # number of training samples
@@ -9,7 +11,7 @@ data:
   dataset: "cifar" # either cifar or imagenet
 
 train:
-  batch_size: 32
+  batch_size: 10
   epochs: 10
   learning_rate: 0.01
 

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ experiment:
   seed: 42 # seed for reproducibility
   test_interval: 5  # test the model every test_interval epochs, None to disable
   vis_train_interval: 5 # plot the training loss every plot_train_interval epochs, None to disable
+  wandb_log: True # log the experiment to wandb
 
 data:
   n_train: 10 # number of training samples
@@ -12,7 +13,7 @@ data:
 
 train:
   batch_size: 10
-  epochs: 10
+  epochs: 5
   learning_rate: 0.01
 
 model:

--- a/pml.def
+++ b/pml.def
@@ -3,6 +3,7 @@ From: python:3.10
 
 %environment
     export PROJECT_ROOT=$PWD
+    export WANDB_API_KEY=<your key>
 
 %files
     $PWD/requirements.txt requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ matplotlib~=3.9.2
 pillow~=11.0.0
 torchvision
 scipy==1.14.1
+PyYAML
+tqdm

--- a/src/pml_vqvae/baseline/autoencoder.py
+++ b/src/pml_vqvae/baseline/autoencoder.py
@@ -100,7 +100,7 @@ class BaselineAutoencoder(PML_model):
         reconstruction = self.decoder_stack(latent)
 
         reconstruction = torch.clamp(reconstruction, 0.0, 1.0)
-        return (reconstruction,)
+        return reconstruction
 
     @staticmethod
     def loss_fn(model_outputs, target):
@@ -117,7 +117,7 @@ class BaselineAutoencoder(PML_model):
     def visualize_output(batch, output, target, prefix: str = "", base_dir: str = "."):
         show_image_grid(batch, outfile=os.path.join(base_dir, f"{prefix}_original.png"))
         show_image_grid(
-            output[0],
+            output,
             outfile=os.path.join(base_dir, f"{prefix}_reconstruction.png"),
         )
 

--- a/src/pml_vqvae/cli_input_handler.py
+++ b/src/pml_vqvae/cli_input_handler.py
@@ -10,14 +10,17 @@ class CLI_handler:
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument(
             "--name",
+            "-n",
             help="name of the experiment. If not provided, the name from the config file will be used",
         )
         self.parser.add_argument(
             "--description",
+            "-d",
             help="description of the experiment. If not provided, the description from the config file will be used",
         )
         self.parser.add_argument(
             "--seed",
+            "-s",
             help="seed for reproducibility. If not provided, the seed from the config file will be used",
         )
         self.parser.add_argument(
@@ -30,22 +33,27 @@ class CLI_handler:
         )
         self.parser.add_argument(
             "--batch_size",
+            "-bs",
             help="batch size for training. If not provided, the batch size from the config file will be used",
         )
         self.parser.add_argument(
             "--epochs",
+            "-e",
             help="number of epochs for training. If not provided, the number from the config file will be used",
         )
         self.parser.add_argument(
             "--learning_rate",
+            "-lr",
             help="learning rate for training. If not provided, the learning rate from the config file will be used",
         )
         self.parser.add_argument(
             "--model_name",
+            "-mn",
             help="name of the model to train. If not provided, the model name from the config file will be used",
         )
         self.parser.add_argument(
             "--dataset",
+            "-ds",
             help="name of the dataset to use. If not provided, the dataset name from the config file will be used",
         )
 

--- a/src/pml_vqvae/cli_input_handler.py
+++ b/src/pml_vqvae/cli_input_handler.py
@@ -4,7 +4,7 @@ from pml_vqvae.config_class import Config
 
 
 class CLI_handler:
-    """Command line interface handler"""
+    """Command line interface handler for maximum flexibility in desinging experiments"""
 
     def __init__(self):
         self.parser = argparse.ArgumentParser()
@@ -56,6 +56,16 @@ class CLI_handler:
             "-ds",
             help="name of the dataset to use. If not provided, the dataset name from the config file will be used",
         )
+        self.parser.add_argument(
+            "--test_interval",
+            "-ti",
+            help="interval for testing the model. If not provided, the interval from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--vis_train_interval",
+            "-vti",
+            help="interval for visualizing the training process. If not provided, the interval from the config file will be used",
+        )
 
     def parse_args(self):
         """Parse command line arguments
@@ -98,5 +108,9 @@ class CLI_handler:
             config.model_name = args.model_name
         if args.dataset:
             config.dataset = args.dataset
+        if args.test_interval:
+            config.test_interval = args.test_interval
+        if args.vis_train_interval:
+            config.vis_train_interval = args.vis_train_interval
 
         return config

--- a/src/pml_vqvae/cli_input_handler.py
+++ b/src/pml_vqvae/cli_input_handler.py
@@ -66,6 +66,11 @@ class CLI_handler:
             "-vti",
             help="interval for visualizing the training process. If not provided, the interval from the config file will be used",
         )
+        self.parser.add_argument(
+            "--wandb_log",
+            "-wl",
+            help="log results to wandb. If not provided, the wandb log from the config file will be used",
+        )
 
     def parse_args(self):
         """Parse command line arguments
@@ -112,5 +117,7 @@ class CLI_handler:
             config.test_interval = args.test_interval
         if args.vis_train_interval:
             config.vis_train_interval = args.vis_train_interval
+        if args.wandb_log:
+            config.wandb_log = args.wandb_log
 
         return config

--- a/src/pml_vqvae/cli_input_handler.py
+++ b/src/pml_vqvae/cli_input_handler.py
@@ -1,0 +1,94 @@
+import argparse
+
+from pml_vqvae.config_class import Config
+
+
+class CLI_handler:
+    """Command line interface handler"""
+
+    def __init__(self):
+        self.parser = argparse.ArgumentParser()
+        self.parser.add_argument(
+            "--name",
+            help="name of the experiment. If not provided, the name from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--description",
+            help="description of the experiment. If not provided, the description from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--seed",
+            help="seed for reproducibility. If not provided, the seed from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--n_train",
+            help="number of training samples. If not provided, the number from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--n_test",
+            help="number of test samples. If not provided, the number from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--batch_size",
+            help="batch size for training. If not provided, the batch size from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--epochs",
+            help="number of epochs for training. If not provided, the number from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--learning_rate",
+            help="learning rate for training. If not provided, the learning rate from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--model_name",
+            help="name of the model to train. If not provided, the model name from the config file will be used",
+        )
+        self.parser.add_argument(
+            "--dataset",
+            help="name of the dataset to use. If not provided, the dataset name from the config file will be used",
+        )
+
+    def parse_args(self):
+        """Parse command line arguments
+
+        Returns:
+            argparse.Namespace: Command line arguments
+        """
+
+        args = self.parser.parse_args()
+        return args
+
+    def adjust_config(self, config: Config, args: argparse.Namespace):
+        """Adjust the configuration object based on the command line arguments
+
+        Args:
+            config (Config): Configuration object
+            args (argparse.Namespace): Command line arguments
+
+        Returns:
+            Config: Adjusted configuration object
+        """
+
+        if args.name:
+            config.name = args.name
+        if args.description:
+            config.description = args.description
+        if args.seed:
+            config.seed = args.seed
+        if args.n_train:
+            config.n_train = args.n_train
+        if args.n_test:
+            config.n_test = args.n_test
+        if args.batch_size:
+            config.batch_size = args.batch_size
+        if args.epochs:
+            config.epochs = args.epochs
+        if args.learning_rate:
+            config.learning_rate = args.learning_rate
+        if args.model_name:
+            config.model_name = args.model_name
+        if args.dataset:
+            config.dataset = args.dataset
+
+        return config

--- a/src/pml_vqvae/config_class.py
+++ b/src/pml_vqvae/config_class.py
@@ -19,6 +19,7 @@ class Config:
         self.output_dir = None
         self.test_interval = None
         self.vis_train_interval = None
+        self.wandb_log = None
 
         # data
         self.dataset = None
@@ -33,6 +34,14 @@ class Config:
 
         # model
         self.model_name = None
+
+    def to_dict(self):
+        """Convert the configuration to a dictionary
+
+        Returns:
+            dict: Configuration dictionary
+        """
+        return self.__dict__
 
     @classmethod
     def from_dict(cls, config: dict):

--- a/src/pml_vqvae/config_class.py
+++ b/src/pml_vqvae/config_class.py
@@ -6,19 +6,6 @@ AVAIL_DATASETS = ["cifar", "imagenet"]
 AVAIL_MODELS = ["vae", "autoencoder"]
 
 
-MODEL = BaselineAutoencoder()
-DATASET = "cifar"
-
-EPOCHS = 5
-LEARNING_RATE = 0.01
-MOMENTUM = 0.9
-N_TRAIN = 1000
-N_TEST = 1000
-BATCH_SIZE = 32
-
-SEED = 2024
-
-
 class Config:
     """Configuration class for the training process"""
 
@@ -26,24 +13,23 @@ class Config:
         """Initialize the a default configuration class"""
 
         # experiment
-        self.name = "default"
-        self.description = "Default confirguration"
-        self.save_dir = "checkpoints"
-        self.log_dir = "logs"
+        self.name = None
+        self.description = None
+        self.output_dir = None
 
         # data
-        self.dataset = DATASET
-        self.n_train = N_TRAIN
-        self.n_test = N_TEST
-        self.seed = SEED
+        self.dataset = None
+        self.n_train = None
+        self.n_test = None
+        self.seed = None
 
         # train
-        self.batch_size = BATCH_SIZE
-        self.epochs = EPOCHS
-        self.learning_rate = LEARNING_RATE
+        self.batch_size = None
+        self.epochs = None
+        self.learning_rate = None
 
         # model
-        self.model = MODEL
+        self.model_name = None
 
     @classmethod
     def from_dict(cls, config: dict):
@@ -65,24 +51,41 @@ class Config:
                     )
                 setattr(conf, key, value)
 
-                if key == "model_name":
-                    if value == "autoencoder":
-                        conf.model = BaselineAutoencoder()
-                    elif value == "vae":
-                        conf.model = BaselineVariationalAutoencoder()
-                    else:
-                        assert value in AVAIL_MODELS, "Unknown model"
+                if key == "name":
+                    setattr(conf, "output_dir", f"{value}_output/")
 
-                elif key == "dataset":
-                    assert value in AVAIL_DATASETS, "Unknown dataset"
+        conf.integrity_check()
 
         return conf
 
-    def summary(self):
-        """Print a summary of the configuration"""
-        print("Configuration:")
+    def integrity_check(self):
+        """Check if the configuration is complete"""
         for key, value in self.__dict__.items():
-            print(f"{key}: {value}")
+            if value is None:
+                raise ValueError(f"Parameter {key} is not set in the configuration")
+
+            if key == "dataset" and value not in AVAIL_DATASETS:
+                raise ValueError(
+                    f"Dataset {value} is not available. Choose from {AVAIL_DATASETS}"
+                )
+
+            if key == "model_name" and value not in AVAIL_MODELS:
+                raise ValueError(
+                    f"Model {value} is not available. Choose from {AVAIL_MODELS}"
+                )
+
+    def __str__(self):
+        """Return a string representation of the configuration"""
+        return str(self.__dict__)
+
+    def get_model(self):
+        """Return the model based on the model name"""
+        if self.model_name == "vae":
+            return BaselineVariationalAutoencoder()
+        elif self.model_name == "autoencoder":
+            return BaselineAutoencoder()
+
+        raise ValueError(f"Model {self.model_name} is not available.")
 
 
 if __name__ == "__main__":

--- a/src/pml_vqvae/config_class.py
+++ b/src/pml_vqvae/config_class.py
@@ -17,6 +17,8 @@ class Config:
         self.name = None
         self.description = None
         self.output_dir = None
+        self.test_interval = None
+        self.vis_train_interval = None
 
         # data
         self.dataset = None
@@ -68,7 +70,8 @@ class Config:
         """Check if the configuration is complete"""
         for key, value in self.__dict__.items():
             if value is None:
-                raise ValueError(f"Parameter {key} is not set in the configuration")
+                if key not in ["description", "test_interval", "vis_train_interval"]:
+                    raise ValueError(f"Parameter {key} is not set in the configuration")
 
             if key == "dataset" and value not in AVAIL_DATASETS:
                 raise ValueError(

--- a/src/pml_vqvae/config_class.py
+++ b/src/pml_vqvae/config_class.py
@@ -1,0 +1,95 @@
+from pml_vqvae.baseline.autoencoder import BaselineAutoencoder
+from pml_vqvae.baseline.vae import BaselineVariationalAutoencoder
+import yaml
+
+AVAIL_DATASETS = ["cifar", "imagenet"]
+AVAIL_MODELS = ["vae", "autoencoder"]
+
+
+MODEL = BaselineAutoencoder()
+DATASET = "cifar"
+
+EPOCHS = 5
+LEARNING_RATE = 0.01
+MOMENTUM = 0.9
+N_TRAIN = 1000
+N_TEST = 1000
+BATCH_SIZE = 32
+
+SEED = 2024
+
+
+class Config:
+    """Configuration class for the training process"""
+
+    def __init__(self):
+        """Initialize the a default configuration class"""
+
+        # experiment
+        self.name = "default"
+        self.description = "Default confirguration"
+        self.save_dir = "checkpoints"
+        self.log_dir = "logs"
+
+        # data
+        self.dataset = DATASET
+        self.n_train = N_TRAIN
+        self.n_test = N_TEST
+        self.seed = SEED
+
+        # train
+        self.batch_size = BATCH_SIZE
+        self.epochs = EPOCHS
+        self.learning_rate = LEARNING_RATE
+
+        # model
+        self.model = MODEL
+
+    @classmethod
+    def from_dict(cls, config: dict):
+        """Create a configuration object from a dictionary
+
+        Args:
+            config (dict): Configuration dictionary
+
+        Returns:
+            Config: Configuration object
+        """
+
+        conf = cls()
+        for _, params in config.items():
+            for key, value in params.items():
+                if not hasattr(conf, key):
+                    print(
+                        f"Warning: {key} is not a valid parameter as part of the configuration. It will be ignored."
+                    )
+                setattr(conf, key, value)
+
+                if key == "model_name":
+                    if value == "autoencoder":
+                        conf.model = BaselineAutoencoder()
+                    elif value == "vae":
+                        conf.model = BaselineVariationalAutoencoder()
+                    else:
+                        assert value in AVAIL_MODELS, "Unknown model"
+
+                elif key == "dataset":
+                    assert value in AVAIL_DATASETS, "Unknown dataset"
+
+        return conf
+
+    def summary(self):
+        """Print a summary of the configuration"""
+        print("Configuration:")
+        for key, value in self.__dict__.items():
+            print(f"{key}: {value}")
+
+
+if __name__ == "__main__":
+
+    with open("config.yaml", "r") as file:
+        config = yaml.safe_load(file)
+
+    config = Config.from_dict(config)
+
+    print("done")

--- a/src/pml_vqvae/config_class.py
+++ b/src/pml_vqvae/config_class.py
@@ -1,6 +1,7 @@
 from pml_vqvae.baseline.autoencoder import BaselineAutoencoder
 from pml_vqvae.baseline.vae import BaselineVariationalAutoencoder
 import yaml
+import os
 
 AVAIL_DATASETS = ["cifar", "imagenet"]
 AVAIL_MODELS = ["vae", "autoencoder"]
@@ -52,7 +53,12 @@ class Config:
                 setattr(conf, key, value)
 
                 if key == "name":
-                    setattr(conf, "output_dir", f"{value}_output/")
+                    outdir = f"artifacts/{value}_output"
+                    setattr(conf, "output_dir", outdir)
+
+                    os.makedirs(f"{outdir}/models/", exist_ok=True)
+                    os.makedirs(f"{outdir}/visuals/", exist_ok=True)
+                    os.makedirs(f"{outdir}/plots/", exist_ok=True)
 
         conf.integrity_check()
 

--- a/src/pml_vqvae/stats_class.py
+++ b/src/pml_vqvae/stats_class.py
@@ -1,0 +1,80 @@
+import matplotlib.pyplot as plt
+
+
+class StatsKeeper:
+    """Class to keep track of stats during training and testing
+
+    Args:
+        output_dir (str, optional): The output directory to save the plots to. Defaults to None.
+
+    Raises:
+        ValueError: If output_dir is not set
+    """
+
+    def __init__(self, output_dir: str = None):
+
+        self.output_dir = output_dir
+
+        self.train_epoch_stats = {}
+        self.train_batch_stats = {}
+
+        self.test_epoch_stats = {}
+        self.test_batch_stats = {}
+
+    def add_batch_stats(self, stats: dict, train: bool = True):
+        """Add stats for one batch
+
+        Args:
+            stats (dict): The stats to add
+            train (bool, optional): Whether this is a training batch. Defaults to True.
+
+        Returns:
+            str: A string representation of the stats
+        """
+        for key, value in stats.items():
+            if train:
+                self.train_batch_stats.setdefault(key, []).append(value)
+            else:
+                self.test_batch_stats.setdefault(key, []).append(value)
+
+        return f"[{'train' if train else 'test'}] " + " | ".join(
+            [f"{k}:{v:.2f}" for k, v in stats.items()]
+        )
+
+    def batch_summarize(self, train: bool = True):
+        """Summarize the stats for the epoch
+
+        Args:
+            train (bool, optional): Whether this is a training epoch. Defaults to True.
+        """
+
+        if train:
+            train_batch_stats = {
+                k: sum(v) / len(v) for k, v in self.train_batch_stats.items()
+            }
+
+            for key, value in train_batch_stats.items():
+                self.train_epoch_stats.setdefault(key, []).append(value)
+
+            self.train_batch_stats = {}
+        else:
+            test_batch_stats = {
+                k: sum(v) / len(v) for k, v in self.test_batch_stats.items()
+            }
+
+            for key, value in test_batch_stats.items():
+                self.test_epoch_stats.setdefault(key, []).append(value)
+
+            self.test_batch_stats = {}
+
+    def visualize(self):
+        """Visualize the stats and save the plots to the output directory"""
+        if self.output_dir is None:
+            raise ValueError("Output directory is not set")
+
+        for stat in self.train_epoch_stats.keys():
+            plt.clf()
+            plt.plot(self.train_epoch_stats[stat])
+            plt.plot(self.test_epoch_stats[stat])
+            plt.title(stat)
+            plt.savefig(f"{self.output_dir}/plots/{stat}.png")

--- a/src/pml_vqvae/stats_class.py
+++ b/src/pml_vqvae/stats_class.py
@@ -1,4 +1,10 @@
 import matplotlib.pyplot as plt
+import wandb
+import os
+import torch
+from pml_vqvae.baseline.pml_model_interface import PML_model
+from pml_vqvae.config_class import Config
+import numpy as np
 
 
 class StatsKeeper:
@@ -11,7 +17,7 @@ class StatsKeeper:
         ValueError: If output_dir is not set
     """
 
-    def __init__(self, output_dir: str = None):
+    def __init__(self, config: Config, output_dir: str = None):
 
         self.output_dir = output_dir
 
@@ -20,6 +26,15 @@ class StatsKeeper:
 
         self.test_epoch_stats = {}
         self.test_batch_stats = {}
+
+        self.wandb_log = config.wandb_log
+
+        self.epoch_cnt = 0
+
+        if config.wandb_log:
+            wandb.login(key=os.environ["WANDB_API_KEY"])
+            wandb.init(project="pml_vqvae", name=config.name, config=config.to_dict())
+            # wandb.watch(model, log_freq=1)
 
     def add_batch_stats(self, stats: dict, train: bool = True):
         """Add stats for one batch
@@ -49,23 +64,71 @@ class StatsKeeper:
         """
 
         if train:
-            train_batch_stats = {
+            train_epoch_stats = {
                 k: sum(v) / len(v) for k, v in self.train_batch_stats.items()
             }
 
-            for key, value in train_batch_stats.items():
+            for key, value in train_epoch_stats.items():
                 self.train_epoch_stats.setdefault(key, []).append(value)
 
+            if self.wandb_log:
+                train_epoch_stats = {
+                    "train/" + k: v for k, v in train_epoch_stats.items()
+                }
+                wandb.log(train_epoch_stats, step=self.epoch_cnt)
+
+            self.epoch_cnt += 1
             self.train_batch_stats = {}
         else:
-            test_batch_stats = {
+            test_epoch_stats = {
                 k: sum(v) / len(v) for k, v in self.test_batch_stats.items()
             }
 
-            for key, value in test_batch_stats.items():
+            for key, value in test_epoch_stats.items():
                 self.test_epoch_stats.setdefault(key, []).append(value)
 
+            if self.wandb_log:
+                test_epoch_stats = {"test/" + k: v for k, v in test_epoch_stats.items()}
+                wandb.log(test_epoch_stats, step=self.epoch_cnt)
+
             self.test_batch_stats = {}
+
+    def save_examples(self, batch, output, epoch: int):
+        if self.wandb_log:
+            payload = {
+                "examples": [
+                    wandb.Image(np.moveaxis(batch[i].cpu().detach().numpy(), 0, -1))
+                    for i in range(len(batch))
+                ],
+                "reconstructions": [
+                    wandb.Image(np.moveaxis(output[i].cpu().detach().numpy(), 0, -1))
+                    for i in range(len(batch))
+                ],
+            }
+            wandb.log(payload, step=epoch)
+
+    def save_model(self, model: PML_model, epoch: int):
+        """Save the model to the output directory
+
+        Args:
+            model (PML_model): The model to save
+            epoch (int): The current epoch
+        """
+        if self.output_dir is None:
+            raise ValueError("Output directory is not set")
+
+        name = f"{self.output_dir}/model_{epoch}.pth"
+        torch.save(model.state_dict(), name)
+
+        if self.wandb_log:
+            wandb.save(name)
+
+    def finish(self):
+        """Finish the logging process"""
+        if self.wandb_log:
+            wandb.finish()
+        else:
+            self.visualize()
 
     def visualize(self):
         """Visualize the stats and save the plots to the output directory"""

--- a/src/pml_vqvae/train.py
+++ b/src/pml_vqvae/train.py
@@ -162,7 +162,7 @@ def train(config: Config):
             model, train_loader, optimizer, stats_keeper
         )
 
-        if i % 1 == 0:
+        if config.vis_train_interval and i % config.vis_train_interval == 0:
             model.visualize_output(
                 batch,
                 output,
@@ -172,10 +172,10 @@ def train(config: Config):
             )
 
         # test on all data for one epoch
-        with torch.no_grad():
-            batch, target, output = test(model, test_loader, stats_keeper)
+        if config.test_interval and i % config.test_interval == 0:
+            with torch.no_grad():
+                batch, target, output = test(model, test_loader, stats_keeper)
 
-            if i % 1 == 0:
                 model.visualize_output(
                     batch,
                     output,

--- a/src/pml_vqvae/train.py
+++ b/src/pml_vqvae/train.py
@@ -1,17 +1,12 @@
 "Python script to train different models"
 
 import os
-import argparse
 import matplotlib.pyplot as plt
-from pml_vqvae.baseline.autoencoder import BaselineAutoencoder
-from pml_vqvae.baseline.vae import BaselineVariationalAutoencoder
-from pml_vqvae.baseline.pml_model_interface import PML_model
 from pml_vqvae.cli_input_handler import CLI_handler
 from pml_vqvae.config_class import Config
 from pml_vqvae.dataset.dataloader import load_data
 import torch
 from torchvision.transforms import v2
-import numpy as np
 import yaml
 from tqdm.auto import tqdm
 

--- a/src/pml_vqvae/train.py
+++ b/src/pml_vqvae/train.py
@@ -84,7 +84,7 @@ def train(config: Config):
         losses.append(epoch_loss)
         train_log(epoch_loss, i, config.epochs)
 
-    torch.save(model.state_dict(), "testmodel_5ep.pth")
+    torch.save(model.state_dict(), f"{config.output_dir}/testmodel_5ep.pth")
     # losses can be either a list of floats (autoencoder) or a list of lists (VAE)
     return np.array(losses)
 

--- a/src/pml_vqvae/train.py
+++ b/src/pml_vqvae/train.py
@@ -1,23 +1,23 @@
 "Python script to train different models"
 
 import os
-import matplotlib.pyplot as plt
+from pml_vqvae.baseline.pml_model_interface import PML_model
 from pml_vqvae.cli_input_handler import CLI_handler
 from pml_vqvae.config_class import Config
 from pml_vqvae.dataset.dataloader import load_data
+from torch.utils.data import DataLoader
 import torch
+from torch.optim import Adam, Optimizer
 from torchvision.transforms import v2
 import yaml
 from tqdm.auto import tqdm
+
+from pml_vqvae.stats_class import StatsKeeper
 
 # import wandb
 DEFAULT_CONFIG = "config.yaml"
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
-
-os.makedirs("artifacts/models/", exist_ok=True)
-os.makedirs("artifacts/visuals/", exist_ok=True)
-os.makedirs("artifacts/plots/", exist_ok=True)
 
 
 # From wandb tutotial https://docs.wandb.ai/tutorials/pytorch
@@ -25,6 +25,95 @@ def train_log(loss, epoch, epochs):
     # Where the magic happens
     # wandb.log({"epoch": epoch, "loss": loss}, step=epoch)
     print(f"Epoch {epoch+1}/{epochs} - Loss: {loss}")
+
+
+def test(model: PML_model, test_loader: DataLoader, stats_keeper: StatsKeeper):
+    """Test a model on a dataset
+
+    Args:
+        model (PML_model): The model to test
+        test_loader (DataLoader): The data loader to use
+        stats_keeper (StatsKeeper): The stats keeper to use
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: The last batch, target and output
+    """
+
+    model.eval()
+
+    # for dynamic logging
+    test_tqdm = tqdm(test_loader)
+
+    for batch, target in test_tqdm:
+        batch = batch.to(DEVICE)
+        target = target.to(DEVICE)
+
+        output = model(batch)
+        loss = model.loss_fn(output, target)
+
+        # collect model specific stats
+        stats = model.collect_stats(output, target, loss)
+
+        # collect all stats in Object for later plotting
+        dsp = stats_keeper.add_batch_stats(stats, train=False)
+
+        # make a nice progress bar
+        test_tqdm.set_description(dsp)
+
+    # create epoch level stats
+    stats_keeper.batch_summarize(train=False)
+
+    model.train()
+
+    return batch, target, output
+
+
+def train_epoch(
+    model: PML_model,
+    train_loader: DataLoader,
+    optimizer: Optimizer,
+    stats_keeper: StatsKeeper,
+):
+    """Train a model on a dataset for one epoch
+
+    Args:
+        model (PML_model): The model to train
+        train_loader (DataLoader): The data loader to use
+        optimizer (Optimizer): The optimizer to use
+        stats_keeper (StatsKeeper): The stats keeper to use
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: The last batch, target and output
+    """
+
+    # for dynamic logging
+    train_tqdm = tqdm(train_loader)
+
+    for batch, target in train_tqdm:
+        batch = batch.to(DEVICE)
+        target = target.to(DEVICE)
+
+        optimizer.zero_grad()
+
+        output = model(batch)
+        loss = model.loss_fn(output, target)
+        model.backward(loss)
+
+        # collect model specific stats
+        stats = model.collect_stats(output, target, loss)
+
+        # collect all stats in Object for later plotting
+        dsp = stats_keeper.add_batch_stats(stats)
+
+        # make a nice progress bar
+        train_tqdm.set_description(dsp)
+
+        optimizer.step()
+
+    # create epoch level stats
+    stats_keeper.batch_summarize()
+
+    return batch, target, output
 
 
 def train(config: Config):
@@ -60,36 +149,18 @@ def train(config: Config):
         seed=config.seed,
     )
 
-    optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+    optimizer = Adam(model.parameters(), lr=config.learning_rate)
 
     model.to(DEVICE)
 
     print("Training model...")
-    train_epoch_stats = {}
-    test_epoch_stats = {}
+    stats_keeper = StatsKeeper(output_dir=config.output_dir)
 
     for i in range(config.epochs):
-        train_batch_stats = {}
-        train_tqdm = tqdm(train_loader)
-        for batch, target in train_tqdm:
-            batch = batch.to(DEVICE)
-            target = target.to(DEVICE)
-
-            optimizer.zero_grad()
-
-            output = model(batch)
-            loss = model.loss_fn(output, target)
-            model.backward(loss)
-
-            stats = model.collect_stats(output, target, loss)
-            for key, value in stats.items():
-                train_batch_stats.setdefault(key, []).append(value)
-
-            train_tqdm.set_description(
-                "[train] " + " | ".join([f"{k}:{v:.2f}" for k, v in stats.items()])
-            )
-
-            optimizer.step()
+        # train on all datat for one epoch
+        batch, target, output = train_epoch(
+            model, train_loader, optimizer, stats_keeper
+        )
 
         if i % 1 == 0:
             model.visualize_output(
@@ -97,35 +168,12 @@ def train(config: Config):
                 output,
                 target,
                 prefix=f"train_epoch{i}",
-                base_dir=f"{config.output_dir}/visuals",
+                base_dir=os.path.join(config.output_dir, "visuals"),
             )
 
-        train_batch_stats = {k: sum(v) / len(v) for k, v in train_batch_stats.items()}
-        for key, value in train_batch_stats.items():
-            train_epoch_stats.setdefault(key, []).append(value)
-
+        # test on all data for one epoch
         with torch.no_grad():
-            model.eval()
-
-            test_batch_stats = {}
-            test_tqdm = tqdm(test_loader)
-
-            for batch, target in test_tqdm:
-                batch = batch.to(DEVICE)
-                target = target.to(DEVICE)
-
-                output = model(batch)
-                loss = model.loss_fn(output, target)
-
-                stats = model.collect_stats(output, target, loss)
-                for key, value in stats.items():
-                    test_batch_stats.setdefault(key, []).append(value)
-
-                test_tqdm.set_description(
-                    "[test] " + " | ".join([f"{k}:{v:.2f}" for k, v in stats.items()])
-                )
-
-            model.train()
+            batch, target, output = test(model, test_loader, stats_keeper)
 
             if i % 1 == 0:
                 model.visualize_output(
@@ -133,23 +181,17 @@ def train(config: Config):
                     output,
                     target,
                     prefix=f"test_epoch{i}",
-                    base_dir=f"{config.output_dir}/visuals",
+                    base_dir=os.path.join(config.output_dir, "visuals"),
                 )
 
-            test_batch_stats = {k: sum(v) / len(v) for k, v in test_batch_stats.items()}
-            for key, value in test_batch_stats.items():
-                test_epoch_stats.setdefault(key, []).append(value)
-
     print("Saving model...")
-    torch.save(model.state_dict(), f"{config.output_dir}/models/testmodel_5ep.pth")
+    torch.save(
+        model.state_dict(),
+        os.path.join(config.output_dir, "models", f"{config.model_name}.pth"),
+    )
 
     print("Plotting stats...")
-    for stat in train_epoch_stats.keys():
-        plt.clf()
-        plt.plot(train_epoch_stats[stat])
-        plt.plot(test_epoch_stats[stat])
-        plt.title(stat)
-        plt.savefig(f"{config.output_dir}/plots/{stat}.png")
+    stats_keeper.visualize()
 
 
 cli_handler = CLI_handler()
@@ -163,5 +205,4 @@ config = cli_handler.adjust_config(config, args)
 
 print(config)
 
-losses = train(config)
-print(losses)
+train(config)

--- a/src/pml_vqvae/wandb_wrapper.py
+++ b/src/pml_vqvae/wandb_wrapper.py
@@ -1,0 +1,88 @@
+import wandb
+import os
+from pml_vqvae.config_class import Config
+import numpy as np
+
+
+class WANDBWrapper:
+    def __init__(self, config: Config):
+        self.config = config
+        self.log = config.wandb_log
+
+        self.train_expl = None
+        self.test_expl = None
+
+        self.train_example_table = None
+        self.test_example_table = None
+
+    def init(self, model):
+        if self.log:
+            wandb.login(key=os.environ["WANDB_API_KEY"])  # your api key
+            wandb.init(
+                project="pml_vqvae", name=self.config.name, config=self.config.to_dict()
+            )  # DON'T change the project name
+            wandb.watch(model, log_freq=1)  # logs the gradients, too
+
+            self.train_example_table = wandb.Table(
+                columns=["Epoch", "Input", "Reconstructions"]
+            )
+            self.test_example_table = wandb.Table(
+                columns=["Epoch", "Input", "Reconstructions"]
+            )
+
+    def save_model(self, path: str):
+        if self.log:
+            wandb.save(path)
+
+    def prepare_stats(self, train_stats, test_stats, example_cnt):
+        train_stats = {"train/" + k: v for k, v in train_stats.items()}
+        test_stats = {"test/" + k: v for k, v in test_stats.items()}
+        return train_stats | test_stats | {"example_cnt": example_cnt}
+
+    def log_epoch(self, stats, epoch, log_vis):
+
+        if self.log:
+            epoch_stats = self.prepare_stats(*stats)
+
+            wandb.log(epoch_stats, step=epoch)
+
+            if log_vis:
+                self.test_example_table.add_data(
+                    epoch, self.test_expl["Input"], self.test_expl["Reconstructions"]
+                )
+                self.train_example_table.add_data(
+                    epoch, self.train_expl["Input"], self.train_expl["Reconstructions"]
+                )
+
+    def finish(self):
+        """Finish the logging process"""
+
+        if self.log:
+            if self.train_example_table:
+                wandb.log({"train_examples": self.train_example_table})
+            if self.test_example_table:
+                wandb.log({"test_examples": self.test_example_table})
+            wandb.finish()
+
+    def construct_examples(self, batch, output, train=True, max_examples=5):
+
+        if isinstance(output, tuple):
+            output = output[0]
+
+        num_examples = min(len(batch), max_examples)
+
+        payload = {
+            "Input": [
+                wandb.Image(np.moveaxis(batch[i].cpu().detach().numpy(), 0, -1))
+                for i in range(num_examples)
+            ],
+            "Reconstructions": [
+                wandb.Image(np.moveaxis(output[i].cpu().detach().numpy(), 0, -1))
+                for i in range(num_examples)
+            ],
+        }
+
+        if train:
+            self.train_expl = payload
+        else:
+            self.test_expl = payload


### PR DESCRIPTION
War doch iwie schwieriger als gedacht, das halbwegs clean einzubauen. Sollte jetzt aber funktionieren.

Ihr braucht dafür einen wandb account und müsst `export WANDB_API_KEY=<euer key>`  machen. Wenn ihr den Projektnamen nicht ändert und ich euch ins Projekt eingeladen haben sollten wir alle runs sehen.

Ein paar Überlegungen:
- da wir jetzt alles über wandb loggen, weiß ich nicht, ob wir überhapt noch die Funktionalität zum lokalen plotten und visualisieren brauchen. Die Vis Funktion für den Datensatz war eine Anforderung und muss bleiben.
- Iwie hatte ich viel mit den unterschiedlichen Losses zu Kämpfen und finde die Stats_keeper Klasse auch ziemlich unübersichtlich. Vllt kann man das dann mit dem wandb_wrapper kombinieren?
- Ich finde es iwie unsauber, dass die train und test Funktion den letzten output und Batch zurückgeben, die dann geplotten werden. Funktioniert soweit aber KA