### PR TITLE
imagenet hyperclasses

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@
 experiment_name: "code enforced vqvae realness" # name of the experiment
 description: "" # description of the experiment
 seed: 42 # seed for reproducibility
-test_interval: 1  # test the model every test_interval epochs, None to disable
+test_interval: 1 # test the model every test_interval epochs, None to disable
 vis_train_interval: 1 # plot the training loss every plot_train_interval epochs, None to disable
 wandb_log: True # log the experiment to wandb
 
@@ -11,6 +11,7 @@ n_train: 200000 # number of training samples
 n_test: 10000 # number of test samples
 dataset: "imagenet" # either cifar or imagenet
 class_idx: null # list of class indices to use, empty list to use all classes
+hyperclass: True # use hyperclasses
 
 # train config
 batch_size: 128
@@ -38,7 +39,6 @@ model_config:
   hidden_dimension: 256
   embedding_dimension: 256
   codebook_initialization_radius: 0.5
-
 # VAE
 # model_config:
 #   kld_weight: 0.00025

--- a/src/pml_vqvae/dataset/dataloader.py
+++ b/src/pml_vqvae/dataset/dataloader.py
@@ -19,6 +19,7 @@ def load_data(
     shuffle: bool = True,
     class_idx: list = None,
     seed: int = None,
+    hyperclass: bool = False,
 ):
     """Load data from specified dataset
 
@@ -79,6 +80,7 @@ def load_data(
             transform=train_transforms,
             seed=seed,
             class_idx=class_idx,
+            hyperclass=hyperclass,
         )
 
         test_set = ImageNetDataset(
@@ -87,6 +89,7 @@ def load_data(
             transform=test_transforms,
             seed=seed,
             class_idx=class_idx,
+            hyperclass=hyperclass,
         )
 
     elif dataset == "cifar":
@@ -173,7 +176,7 @@ def load_data(
             f"/home/{getpass.getuser()}/pml_vqvae/artifacts/konni_replacement_vqvae/imagenet_latents_200000/test",
             data_per_file=1,
         )
-    
+
     elif dataset.startswith("latent"):
         _, dataset_path = dataset.split()
         print("Getting latent dataset")

--- a/src/pml_vqvae/dataset/hyperclasses.json
+++ b/src/pml_vqvae/dataset/hyperclasses.json
@@ -1,0 +1,51 @@
+{
+    "dog": [
+        "Irish terrier",
+        "Appenzeller",
+        "Leonberg",
+        "golden retriever",
+        "giant schnauzer"
+    ],
+    "cat":[
+        "Egyptian cat",
+        "Persian cat",
+        "Siamese cat",
+        "tabby",
+        "tiger cat"
+    ],
+    "car":[
+        "convertible",
+        "sports car",
+        "racer",
+        "limousine",
+        "jeep"
+    ],
+    "bird":[
+        "bald eagle",
+        "hummingbird",
+        "great grey owl",
+        "white stork",
+        "house finch"
+    ],
+    "ship":[
+        "container ship",
+        "speedboat",
+        "liner",
+        "lifeboat",
+        "fireboat"
+    ],
+    "truck":[
+        "garbage truck",
+        "tow truck",
+        "fire engine",
+        "pickup",
+        "trailer truck"
+    ],
+    "fish":[
+        "goldfish",
+        "coho",
+        "barracouta",
+        "tench",
+        "sturgeon"
+    ]
+}

--- a/src/pml_vqvae/dataset/imagenet.py
+++ b/src/pml_vqvae/dataset/imagenet.py
@@ -41,6 +41,7 @@ def create_imagenet_subset(
     split: str,
     seed: int = None,
     class_idx_list: list = None,
+    hyperclass: bool = False,
 ):
     """Create a subset of the ImageNet dataset with n_samples per class.
 
@@ -56,12 +57,34 @@ def create_imagenet_subset(
 
     full_imagenet = init_imagenet(root_dir, split)
 
+    # create a class_idx_list according to the hyperclasses
+    idx2hyperclasslabel = None
+    if hyperclass:
+        idx2hyperclasslabel = {}
+        hyperclasses = json.load(open("src/pml_vqvae/dataset/hyperclasses.json"))
+
+        class_idx_list = []
+        for i, (_, class_names) in enumerate(hyperclasses.items()):
+            class_idx = []
+
+            for name in class_names:
+                try:
+                    class_idx.append(full_imagenet.class_to_idx[name])
+                except KeyError:
+                    print(f"WARNING: Class {name} not found in ImageNet dataset")
+
+            class_idx_list.extend(class_idx)
+
+            for idx in class_idx:
+                idx2hyperclasslabel[idx] = i
+
     img_subset = []
 
     img_pointer = 0
     # iterate over all classes
     for class_idx in range(len(full_imagenet.classes)):
         class_imgs = []
+
         # iterate over all images starting from last pointer
         for idx in range(img_pointer, len(full_imagenet.imgs)):
             path, img_class_idx = full_imagenet.imgs[idx]
@@ -95,7 +118,7 @@ def create_imagenet_subset(
     subset_imagenet.samples = img_subset
     subset_imagenet.targets = [img[1] for img in img_subset]
 
-    return subset_imagenet
+    return subset_imagenet, idx2hyperclasslabel
 
 
 class ImageNetDataset(Dataset):
@@ -117,14 +140,25 @@ class ImageNetDataset(Dataset):
         seed: int = None,
         transform=None,
         class_idx: list = None,
+        hyperclass: bool = False,
     ):
         super().__init__()
 
         # root directory of the dataset
         self.root_dir = os.path.join(root_dir, split)
 
-        if samples_per_class is not None or class_idx is not None:
-            self.imagenet = create_imagenet_subset(
+        self.is_hyperclass = hyperclass
+        if hyperclass:
+            self.imagenet, self.idx2hyperclasslabel = create_imagenet_subset(
+                root_dir,
+                samples_per_class,
+                split,
+                seed=seed,
+                class_idx_list=class_idx,
+                hyperclass=True,
+            )
+        elif samples_per_class is not None or class_idx is not None:
+            self.imagenet, _ = create_imagenet_subset(
                 root_dir, samples_per_class, split, seed=seed, class_idx_list=class_idx
             )
             self.samples_per_class = samples_per_class
@@ -153,7 +187,10 @@ class ImageNetDataset(Dataset):
         if self.transform:
             image = self.transform(image)
 
-        return image, self.imagenet.targets[idx]
+        if self.is_hyperclass:
+            return image, self.idx2hyperclasslabel[self.imagenet.targets[idx]]
+        else:
+            return image, self.imagenet.targets[idx]
 
     def export_class_dist(self, outfile="./imagenet_dist"):
         """Export the class distribution of the dataset as a histogram.

--- a/src/pml_vqvae/train.py
+++ b/src/pml_vqvae/train.py
@@ -141,6 +141,7 @@ def train(config: TrainConfig):
         seed=config.seed,
         class_idx=config.class_idx,
         batch_size=config.batch_size,
+        hyperclass=config.hyperclass,
     )
 
     optimizer = config.get_optimizer(model)

--- a/src/pml_vqvae/train_config.py
+++ b/src/pml_vqvae/train_config.py
@@ -46,6 +46,7 @@ class TrainConfig:
     n_test: int | None = None
     seed: int | None = None
     class_idx: int | None = None
+    hyperclass: bool = False
 
     # model optionals (some model require a config, others don't)
     model_config: dict | None = None


### PR DESCRIPTION
Gibt ein json file, indem man die hyperclasses definieren kann. Die Namen müssen genauso geschrieben werden, wie sie bei Imagenet zu finden sind. 

Nicht ganz einfach geeignete Hyperklasen zu finden, (1) bei denen es etwa gleich viele examples gibt, (2) die nicht zu nah bei einander sind und (3) bei denen die leaf nodes nicht zu verschieden sind.

Ich habe mal dieses sieben Klassen genommen.